### PR TITLE
Dev yinuo fix itempane conflict

### DIFF
--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -1118,13 +1118,6 @@ var ItemTree = class ItemTree extends LibraryTree {
 				}
 			);
 		}
-		// Close DeepTutor pane when activating items
-		Zotero.debug('06062025: handleActivate() is called!!!!!');
-		let mainWindow = Zotero.getMainWindow();
-		if (mainWindow && mainWindow.ZoteroStandalone) {
-			Zotero.debug('06062025: ZoteroStandalone is defined and used!!!!!');
-			mainWindow.ZoteroStandalone.closeDeepTutorPane();
-		}
 		Zotero.debug(`itemTree.render(). Displaying ${showMessage ? "Item Pane Message" : "Item Tree"}`);
 
 		return [

--- a/chrome/content/zotero/itemTree.jsx
+++ b/chrome/content/zotero/itemTree.jsx
@@ -944,6 +944,7 @@ var ItemTree = class ItemTree extends LibraryTree {
 	}
 	
 	handleActivate = (event, indices) => {
+		if (!indices.length) return;
 		// Ignore double-clicks in duplicates view on everything except attachments
 		let items = indices.map(index => this.getRow(index).ref);
 		if (event.button == 0 && this.collectionTreeRow.isDuplicates()) {
@@ -1116,6 +1117,13 @@ var ItemTree = class ItemTree extends LibraryTree {
 					label: Zotero.getString('pane.items.title'),
 				}
 			);
+		}
+		// Close DeepTutor pane when activating items
+		Zotero.debug('06062025: handleActivate() is called!!!!!');
+		let mainWindow = Zotero.getMainWindow();
+		if (mainWindow && mainWindow.ZoteroStandalone) {
+			Zotero.debug('06062025: ZoteroStandalone is defined and used!!!!!');
+			mainWindow.ZoteroStandalone.closeDeepTutorPane();
 		}
 		Zotero.debug(`itemTree.render(). Displaying ${showMessage ? "Item Pane Message" : "Item Tree"}`);
 

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -549,8 +549,6 @@ const ZoteroStandalone = new function() {
 			case 'item-pane':
 				Zotero.debug('06062025_2 Standalone: Item pane toggle triggered before');
 				var itemPane = document.getElementById('zotero-item-pane');
-				var deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
-				var deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
 				Zotero.debug('06062025_2 Standalone: Item pane toggle triggered');
 				
 				// Show
@@ -558,13 +556,6 @@ const ZoteroStandalone = new function() {
 					Zotero.debug('Standalone: Opening item pane');
 					document.getElementById('zotero-items-splitter').setAttribute('state', 'open');
 					itemPane.setAttribute('collapsed', false);
-					
-					// Hide DeepTutor pane if it's visible
-					if (!deepTutorPane.hidden) {
-						Zotero.debug('Standalone: Closing DeepTutor pane while opening item pane');
-						deepTutorPane.hidden = true;
-						deeptutorSplitter.setAttribute('state', 'collapsed');
-					}
 				}
 				// Hide
 				else {
@@ -814,17 +805,6 @@ const ZoteroStandalone = new function() {
 		Zotero.Notifier.unregisterObserver(this._notifierID);
 		ZoteroPane.destroy();
 	}
-
-	this.closeDeepTutorPane = function() {
-		var deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
-		var deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
-		if (deepTutorPane && !deepTutorPane.hidden) {
-			Zotero.debug('Standalone: Closing DeepTutor pane');
-			deepTutorPane.hidden = true;
-			deeptutorSplitter.setAttribute('state', 'collapsed');
-			ZoteroPane.updateLayoutConstraints();
-		}
-	};
 }
 
 

--- a/chrome/content/zotero/standalone/standalone.js
+++ b/chrome/content/zotero/standalone/standalone.js
@@ -512,6 +512,7 @@ const ZoteroStandalone = new function() {
 			return;
 		}
 		id = id.substr(prefix.length);
+		Zotero.debug('06062025 Standalone: View menu item clicked: ' + id);
 		
 		switch (id) {
 			case 'standard':
@@ -546,18 +547,33 @@ const ZoteroStandalone = new function() {
 				break;
 			
 			case 'item-pane':
+				Zotero.debug('06062025_2 Standalone: Item pane toggle triggered before');
 				var itemPane = document.getElementById('zotero-item-pane');
+				var deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
+				var deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
+				Zotero.debug('06062025_2 Standalone: Item pane toggle triggered');
+				
 				// Show
 				if (itemPane.getAttribute('collapsed') == 'true') {
+					Zotero.debug('Standalone: Opening item pane');
 					document.getElementById('zotero-items-splitter').setAttribute('state', 'open');
 					itemPane.setAttribute('collapsed', false);
+					
+					// Hide DeepTutor pane if it's visible
+					if (!deepTutorPane.hidden) {
+						Zotero.debug('Standalone: Closing DeepTutor pane while opening item pane');
+						deepTutorPane.hidden = true;
+						deeptutorSplitter.setAttribute('state', 'collapsed');
+					}
 				}
 				// Hide
 				else {
+					Zotero.debug('Standalone: Closing item pane');
 					document.getElementById('zotero-items-splitter').setAttribute('state', 'collapsed');
 					itemPane.setAttribute('collapsed', true);
 				}
 				ZoteroPane.updateLayoutConstraints();
+				Zotero.debug('Standalone: Layout constraints updated for item pane');
 				break;
 			
 			case 'tag-selector':
@@ -798,6 +814,17 @@ const ZoteroStandalone = new function() {
 		Zotero.Notifier.unregisterObserver(this._notifierID);
 		ZoteroPane.destroy();
 	}
+
+	this.closeDeepTutorPane = function() {
+		var deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
+		var deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
+		if (deepTutorPane && !deepTutorPane.hidden) {
+			Zotero.debug('Standalone: Closing DeepTutor pane');
+			deepTutorPane.hidden = true;
+			deeptutorSplitter.setAttribute('state', 'collapsed');
+			ZoteroPane.updateLayoutConstraints();
+		}
+	};
 }
 
 

--- a/chrome/content/zotero/zoteroPane.js
+++ b/chrome/content/zotero/zoteroPane.js
@@ -83,6 +83,30 @@ var ZoteroPane = new function()
 		// so handleBlur gets triggered when any field, not just the document, looses focus
 		document.addEventListener('focusout', ZoteroPane.handleBlur);
 		
+		// Add observer for item pane collapsed state changes
+		this.itemPane = document.querySelector("#zotero-item-pane");
+		if (this.itemPane) {
+			let observer = new MutationObserver((mutations) => {
+				mutations.forEach((mutation) => {
+					if (mutation.attributeName === 'collapsed') {
+						let isCollapsed = this.itemPane.getAttribute('collapsed') === 'true';
+						if (!isCollapsed) {
+							// Item pane is being opened, close DeepTutor pane
+							let deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
+							let deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
+							if (deepTutorPane && !deepTutorPane.hidden) {
+								Zotero.debug('06062025-Standalone: Closing DeepTutor pane due to item pane opening');
+								deepTutorPane.hidden = true;
+								deeptutorSplitter.setAttribute('state', 'collapsed');
+								ZoteroPane.updateLayoutConstraints();
+							}
+						}
+					}
+				});
+			});
+			observer.observe(this.itemPane, { attributes: true });
+		}
+		
 		// Init toolbar buttons for all progress queues
 		let progressQueueButtons = document.getElementById('zotero-pq-buttons');
 		let progressQueues = Zotero.ProgressQueues.getAll();


### PR DESCRIPTION
Completes functionality: when items pane content is opened (by any way) in main pane mode, the deeptutor pane and splitter will collapse. 
Further issue: When opening: both items pane and deeptutor pane will both open by default, which may not be checked by listener. Possible solutions include 1. make deeptutor pane close, which sacrifices user experience 2. implement the case of closing items pane at the start, which I tried promptly and failed, but should be able to solve given enough time