### PR TITLE
fix: default session name

### DIFF
--- a/chrome/content/zotero/DeepTutorBottomSection.js
+++ b/chrome/content/zotero/DeepTutorBottomSection.js
@@ -57,7 +57,7 @@ const styles = {
         border: 'none',
         color: '#292929',
         fontWeight: 500,
-        fontSize: '1.2rem',
+        fontSize: '1rem',
         lineHeight: '100%',
         letterSpacing: '0%',
         fontFamily: 'Roboto, sans-serif',
@@ -77,8 +77,8 @@ const styles = {
         }
     },
     buttonIcon: {
-        width: '1.25rem',
-        height: '1.25rem',
+        width: '1.1rem',
+        height: '1.1rem',
         objectFit: 'contain',
     },
     upgradeButton: {

--- a/chrome/content/zotero/DeepTutorChatBox.js
+++ b/chrome/content/zotero/DeepTutorChatBox.js
@@ -335,9 +335,10 @@ const styles = {
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
-        '&:hover': {
-            background: '#F8F6F7',
-        },
+        background: '#FFFFFF',
+        border: 'none',
+        width: '100%',
+        textAlign: 'left',
     },
 };
 
@@ -358,6 +359,7 @@ const DeepTutorChatBox = ({ currentSession, key, onSessionSelect }) => {
     const MAX_VISIBLE_SESSIONS = 2;
     const chatLogRef = useRef(null);
     const [hoveredQuestion, setHoveredQuestion] = useState(null);
+    const [hoveredPopupSession, setHoveredPopupSession] = useState(null);
 
     // Load recent sessions from preferences on component mount
     useEffect(() => {
@@ -1484,11 +1486,16 @@ const DeepTutorChatBox = ({ currentSession, key, onSessionSelect }) => {
                                 {hiddenSessions.map(([sessionId, sessionData]) => (
                                     <div
                                         key={sessionId}
-                                        style={styles.sessionPopupItem}
+                                        style={{
+                                            ...styles.sessionPopupItem,
+                                            background: hoveredPopupSession === sessionId ? '#D9D9D9' : '#FFFFFF'
+                                        }}
                                         onClick={() => {
                                             handleSessionClick(sessionId);
                                             setShowSessionPopup(false);
                                         }}
+                                        onMouseEnter={() => setHoveredPopupSession(sessionId)}
+                                        onMouseLeave={() => setHoveredPopupSession(null)}
                                     >
                                         {truncateSessionName(sessionData.name)}
                                     </div>

--- a/chrome/content/zotero/SessionHistory.js
+++ b/chrome/content/zotero/SessionHistory.js
@@ -55,6 +55,11 @@ const searchInputStyle = {
   color: '#1a65b0',
   minHeight: '2rem',
   fontSize: '0.8125rem',
+  ':focus': {
+    outline: 'none',
+    border: 'none',
+    boxShadow: 'none'
+}
 };
 
 const sessionListStyle = {


### PR DESCRIPTION
add default session name functionality for registration (default name is the first file's name, if no file, the name is set to be Default Session which will not apply as there must be at least one document, placeholder display default names, use default names if user input is empty), brief unit tests, bug found that issue of loading new session for duplicated names