### PR TITLE
Dev yinuo 0618fix

### DIFF
--- a/chrome/content/zotero/DeepTutorChatBox.js
+++ b/chrome/content/zotero/DeepTutorChatBox.js
@@ -250,7 +250,8 @@ const styles = {
     },
     sourceButton: {
         all: 'revert',
-        background: '#0AE2FF',
+        background: '#0687E5',
+        opacity: 0.4,
         color: 'white',
         border: 'none',
         borderRadius: '50%',

--- a/chrome/content/zotero/DeepTutorSessionDelete.js
+++ b/chrome/content/zotero/DeepTutorSessionDelete.js
@@ -1,0 +1,166 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SKY = '#0687E5';
+
+const styles = {
+  container: {
+    width: '100%',
+    minHeight: '80%',
+    background: '#FFFFFF',
+    fontFamily: 'Roboto, sans-serif',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'relative',
+  },
+  content: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  title: {
+    background: '#dc3545',
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    backgroundClip: 'text',
+    color: '#dc3545',
+    fontWeight: 700,
+    fontSize: '1.25rem',
+    lineHeight: '100%',
+    letterSpacing: '0%',
+    textAlign: 'center',
+    marginBottom: '1.5rem',
+  },
+  message: {
+    fontSize: '1rem',
+    color: '#000000',
+    textAlign: 'center',
+    marginBottom: '1.875rem',
+    fontWeight: 400,
+    lineHeight: '135%',
+  },
+  buttonContainer: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.625rem',
+  },
+  confirmButton: {
+    all: 'revert',
+    background: '#dc3545',
+    color: '#fff',
+    minHeight: '2.4375rem',
+    fontWeight: 700,
+    fontSize: '1rem',
+    border: 'none',
+    borderRadius: '0.625rem',
+    padding: '0.625rem 1.25rem',
+    width: '100%',
+    cursor: 'pointer',
+    boxShadow: '0 0.0625rem 0.125rem rgba(0,0,0,0.08)',
+    fontFamily: 'Roboto, sans-serif',
+    letterSpacing: 0.2,
+  },
+  confirmButtonHover: {
+    background: '#dc3545',
+  },
+  cancelButton: {
+    all: 'revert',
+    background: '#fff',
+    color: SKY,
+    fontWeight: 700,
+    fontSize: '1rem',
+    minHeight: '2.4375rem',
+    border: `0.125rem solid ${SKY}`,
+    boxShadow: '0 0.0625rem 0.125rem rgba(0,0,0,0.08)',
+    borderRadius: '0.625rem',
+    width: '100%',
+    padding: '0.625rem 1.25rem',
+    cursor: 'pointer',
+    fontFamily: 'Roboto, sans-serif',
+    letterSpacing: 0.2,
+  },
+  cancelButtonHover: {
+    background: '#F8F6F7',
+  }
+};
+
+export default function DeepTutorSessionDelete({ 
+  sessionToDelete, 
+  onConfirmDelete, 
+  onCancelDelete,
+  sessionName = 'this session'
+}) {
+  const [isConfirmHovered, setIsConfirmHovered] = React.useState(false);
+  const [isCancelHovered, setIsCancelHovered] = React.useState(false);
+
+  // Truncate session name if it's too long
+  const truncateSessionName = (name, maxLength = 35) => {
+    if (!name || name.length <= maxLength) {
+      return name;
+    }
+    return name.substring(0, maxLength) + '...';
+  };
+
+  const displaySessionName = truncateSessionName(sessionName);
+
+  const handleConfirm = () => {
+    if (sessionToDelete && onConfirmDelete) {
+      onConfirmDelete(sessionToDelete);
+    }
+  };
+
+  const handleCancel = () => {
+    if (onCancelDelete) {
+      onCancelDelete();
+    }
+  };
+
+  const confirmButtonDynamicStyle = {
+    ...styles.confirmButton,
+    ...(isConfirmHovered ? styles.confirmButtonHover : {})
+  };
+
+  const cancelButtonDynamicStyle = {
+    ...styles.cancelButton,
+    ...(isCancelHovered ? styles.cancelButtonHover : {})
+  };
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.content}>
+        <div style={styles.message}>
+          Are you sure you want to delete "{displaySessionName}"? This action cannot be undone.
+        </div>
+        <div style={styles.buttonContainer}>
+          <button 
+            style={confirmButtonDynamicStyle}
+            onClick={handleConfirm}
+            onMouseEnter={() => setIsConfirmHovered(true)}
+            onMouseLeave={() => setIsConfirmHovered(false)}
+          >
+            Confirm
+          </button>
+          <button 
+            style={cancelButtonDynamicStyle}
+            onClick={handleCancel}
+            onMouseEnter={() => setIsCancelHovered(true)}
+            onMouseLeave={() => setIsCancelHovered(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DeepTutorSessionDelete.propTypes = {
+  sessionToDelete: PropTypes.string,
+  onConfirmDelete: PropTypes.func.isRequired,
+  onCancelDelete: PropTypes.func.isRequired,
+  sessionName: PropTypes.string
+};

--- a/chrome/content/zotero/DeepTutorTopSection.js
+++ b/chrome/content/zotero/DeepTutorTopSection.js
@@ -117,30 +117,6 @@ class DeepTutorTopSection extends React.Component {
         return (
             <div style={styles.contentWrapper}>
                 <img src={this.props.logoPath} alt="DeepTutor Logo" style={styles.logo} />
-                <div style={styles.topRight}>
-                    <button
-                        style={this.getIconButtonStyle(this.props.currentPane === 'modelSelection')}
-                        onClick={() => {
-                            this.props.onToggleSearch && this.props.onToggleSearch();
-                        }}
-                    >
-                        <img 
-                            src={this.props.MicroscopeIconPath}
-                            alt="Microscope" 
-                            style={styles.iconImage}
-                        />
-                    </button>
-                    <button
-                        style={this.getIconButtonStyle(this.props.currentPane === 'modelSelection')}
-                        onClick={this.props.onToggleModelSelectionPopup}
-                    >
-                        <img 
-                            src={this.props.PlusIconPath}
-                            alt="New Session" 
-                            style={styles.iconImage}
-                        />
-                    </button>
-                </div>
             </div>
         );
     }
@@ -171,8 +147,7 @@ DeepTutorTopSection.propTypes = {
     logoPath: PropTypes.string.isRequired,
     HistoryIconPath: PropTypes.string.isRequired,
     PlusIconPath: PropTypes.string.isRequired,
-    MicroscopeIconPath: PropTypes.string.isRequired,
-    onToggleSearch: PropTypes.func,
+    onToggleModelSelectionPopup: PropTypes.func.isRequired,
 };
 
 export default DeepTutorTopSection; 

--- a/chrome/content/zotero/ModelSelection.js
+++ b/chrome/content/zotero/ModelSelection.js
@@ -257,14 +257,14 @@ const styles = {
     marginBottom: '1.25rem',
     display: 'flex',
     flexDirection: 'column',
-    gap: '0.3125rem',
+    gap: '0.625rem',
     width: '100%',
     height: '11rem',
   },
   modelFeature: {
     display: 'flex',
     alignItems: 'flex-start',
-    gap: '0.3125rem',
+    gap: '0.625rem',
     fontSize: '1rem',
     lineHeight: '100%',
     letterSpacing: '0%',
@@ -282,14 +282,17 @@ const styles = {
     marginTop: '0.09375rem',
   },
   modelLimitations: {
-    marginTop: '0.3125rem',
     color: '#000000',
+    gap: '0.625rem',
     fontSize: '1rem',
-    lineHeight: '180%',
+    lineHeight: '100%',
     fontWeight: '400',
     letterSpacing: '0%',
-    width: '90%',
+    width: '100%',
     height: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
   },
   searchContainer: {
     position: 'relative',
@@ -1006,7 +1009,7 @@ function ModelSelection({ onSubmit, user }) {
                       style={styles.newFileListDelete}
                       onClick={() => handleRemoveFile(file.id)}
                     >
-                      <img src={DeleteImg} alt="Delete" width="24" height="24" />
+                      <img src={DeleteImg} alt="Delete" width="15" height="17" />
                     </button>
                   </div>
                 ))}
@@ -1108,10 +1111,10 @@ function ModelSelection({ onSubmit, user }) {
                 <span>Free for all users</span>
               </div>
               <div style={styles.modelLimitations}>
-                ❌ No summary<br />
-                ❌ No image understanding<br />
-                ❌ No advanced model like graphRAG<br />
-                ❌ No source content
+                <span>❌ No summary</span>
+                <span>❌ No image understanding</span>
+                <span>❌ No advanced model like graphRAG</span>
+                <span>❌ No source content</span>
               </div>
             </div>
           )}
@@ -1126,11 +1129,11 @@ function ModelSelection({ onSubmit, user }) {
                 <span>Available with Premium Subscription</span>
               </div>
               <div style={styles.modelLimitations}>
-                ✅ Image understanding<br />
-                ✅ Inference mode with DeepSeek<br />
-                ✅ High quality summary<br />
-                ✅ Source content highlight<br />
-                ✅ Markdown based RAG model
+                <span>✅ Image understanding</span>
+                <span>✅ Inference mode with DeepSeek</span>
+                <span>✅ High quality summary</span>
+                <span>✅ Source content highlight</span>
+                <span>✅ Markdown based RAG model</span>
               </div>
             </div>
           )}
@@ -1145,10 +1148,10 @@ function ModelSelection({ onSubmit, user }) {
                 <span>Available with Premium Subscription</span>
               </div>
               <div style={styles.modelLimitations}>
-                ✅ Everything in standard mode<br />
-                🌟 Deeper understanding on figures, equations, and tables<br />
-                🌟 Further enhanced context relavency<br />
-                🌟 More advanced model using GraphRAG
+                <span>✅ Everything in standard mode</span>
+                <span>🌟 Deeper understanding on figures, equations, and tables</span>
+                <span>🌟 Further enhanced context relavency</span>
+                <span>🌟 More advanced model using GraphRAG</span>
               </div>
             </div>
           )}

--- a/chrome/content/zotero/SessionHistory.js
+++ b/chrome/content/zotero/SessionHistory.js
@@ -156,79 +156,7 @@ const sessionTextStyle = {
   textOverflow: 'ellipsis',
 };
 
-const popupOverlayStyle = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  background: 'rgba(0, 0, 0, 0.5)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  zIndex: 1000,
-};
 
-const popupContentStyle = {
-  background: '#FFFFFF',
-  borderRadius: '0.625rem',
-  padding: '2rem',
-  width: '20rem',
-  maxWidth: '90%',
-  fontFamily: 'Roboto, sans-serif',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  boxShadow: '0 0.25rem 1rem rgba(0,0,0,0.1)',
-};
-
-const popupTitleStyle = {
-  background: 'linear-gradient(90deg, #0AE2FF 0%, #0687E5 100%)',
-  WebkitBackgroundClip: 'text',
-  WebkitTextFillColor: 'transparent',
-  backgroundClip: 'text',
-  color: SKY,
-  fontWeight: 700,
-  fontSize: '1.25rem',
-  lineHeight: '100%',
-  letterSpacing: '0%',
-  textAlign: 'center',
-  marginBottom: '1.5rem',
-};
-
-const popupButtonStyle = {
-  background: SKY,
-  color: '#fff',
-  fontWeight: 700,
-  fontSize: '1rem',
-  border: 'none',
-  borderRadius: '0.625rem',
-  padding: '0.875rem 0',
-  width: '100%',
-  margin: '0 auto 0.625rem auto',
-  cursor: 'pointer',
-  boxShadow: '0 0.0625rem 0.125rem rgba(0,0,0,0.08)',
-  fontFamily: 'Roboto, sans-serif',
-  letterSpacing: 0.2,
-  display: 'block',
-};
-
-const popupCancelButtonStyle = {
-  background: '#fff',
-  color: SKY,
-  fontWeight: 700,
-  fontSize: '1rem',
-  border: `0.125rem solid ${SKY}`,
-  boxShadow: '0 0.0625rem 0.125rem rgba(0,0,0,0.08)',
-  borderRadius: '0.625rem',
-  width: '100%',
-  padding: '0.875rem 0',
-  margin: '0.75rem auto 0 auto',
-  cursor: 'pointer',
-  fontFamily: 'Roboto, sans-serif',
-  letterSpacing: 0.2,
-  display: 'block',
-};
 
 const loadingStyle = {
   width: '100%',
@@ -256,38 +184,18 @@ const plusIconPath = 'chrome://zotero/content/DeepTutorMaterials/History/SESHIS_
 const searchIconPath = 'chrome://zotero/content/DeepTutorMaterials/History/SESHIS_SEARCH.svg';
 const DeleteImg = 'chrome://zotero/content/DeepTutorMaterials/Registration/RES_DELETE.svg';
 
-function SessionHistory({ sessions = [], onSessionSelect, isLoading = false, error = null, showSearch = true, onCreateNewSession, onDeleteSession }) {
+function SessionHistory({ sessions = [], onSessionSelect, isLoading = false, error = null, onCreateNewSession, onShowDeletePopup }) {
   const [search, setSearch] = useState('');
   const [hoveredButton, setHoveredButton] = useState(null);
   const [isCreateSessionHovered, setIsCreateSessionHovered] = useState(false);
-  const [showDeletePopup, setShowDeletePopup] = useState(false);
-  const [sessionToDelete, setSessionToDelete] = useState(null);
 
   const handleCreateSessionMouseEnter = () => setIsCreateSessionHovered(true);
   const handleCreateSessionMouseLeave = () => setIsCreateSessionHovered(false);
 
   const handleDeleteClick = (e, sessionId) => {
     e.stopPropagation();
-    setSessionToDelete(sessionId);
-    setShowDeletePopup(true);
-  };
-
-  const handleConfirmDelete = () => {
-    if (sessionToDelete && onDeleteSession) {
-      onDeleteSession(sessionToDelete);
-    }
-    setShowDeletePopup(false);
-    setSessionToDelete(null);
-  };
-
-  const handleCancelDelete = () => {
-    setShowDeletePopup(false);
-    setSessionToDelete(null);
-  };
-
-  const handlePopupOverlayClick = (e) => {
-    if (e.target === e.currentTarget) {
-      handleCancelDelete();
+    if (onShowDeletePopup) {
+      onShowDeletePopup(sessionId);
     }
   };
 
@@ -329,18 +237,16 @@ function SessionHistory({ sessions = [], onSessionSelect, isLoading = false, err
         <img src={plusIconPath} alt="Plus" style={plusIconStyle} />
       </button>
       {/* Search Bar Section */}
-      {showSearch && (
-        <div style={searchSectionStyle}>
-          <img src={searchIconPath} alt="Search Icon" style={{ width: '1rem', height: '1rem', marginRight: '0.5rem' }} />
-          <input
-            type="text"
-            placeholder="Search for a Session..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            style={searchInputStyle}
-          />
-        </div>
-      )}
+      <div style={searchSectionStyle}>
+        <img src={searchIconPath} alt="Search Icon" style={{ width: '1rem', height: '1rem', marginRight: '0.5rem' }} />
+        <input
+          type="text"
+          placeholder="Search for a Session..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={searchInputStyle}
+        />
+      </div>
       <div style={sessionListTitleStyle}>Sessions</div>
       {/* Session List Section */}
       <div style={sessionListStyle}>
@@ -374,20 +280,7 @@ function SessionHistory({ sessions = [], onSessionSelect, isLoading = false, err
         ))}
       </div>
 
-      {/* Delete Confirmation Popup */}
-      {showDeletePopup && (
-        <div style={popupOverlayStyle} onClick={handlePopupOverlayClick}>
-          <div style={popupContentStyle}>
-            <div style={popupTitleStyle}>Confirm Session Deletion?</div>
-            <button style={popupButtonStyle} onClick={handleConfirmDelete}>
-              Confirm
-            </button>
-            <button style={popupCancelButtonStyle} onClick={handleCancelDelete}>
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
+
     </div>
   );
 }
@@ -401,9 +294,8 @@ SessionHistory.propTypes = {
   onSessionSelect: PropTypes.func,
   isLoading: PropTypes.bool,
   error: PropTypes.string,
-  showSearch: PropTypes.bool,
   onCreateNewSession: PropTypes.func,
-  onDeleteSession: PropTypes.func
+  onShowDeletePopup: PropTypes.func
 };
 
 export default SessionHistory;

--- a/chrome/content/zotero/tabs.js
+++ b/chrome/content/zotero/tabs.js
@@ -511,6 +511,29 @@ var Zotero_Tabs = new function () {
 			// never return focus to another tab or <window>
 			selectedTab.lastFocusedElement = document.activeElement;
 		}
+		
+		// FIX0618: Collapse deeptutor pane when switching to reader mode
+		/*
+		if (tab.type === 'reader' || tab.type === 'reader-unloaded' || tab.type === 'reader-loading') {
+			let deepTutorPane = document.getElementById('new-deep-tutor-pane-container');
+			let deeptutorSplitter = document.getElementById('zotero-deeptutor-splitter');
+			
+			if (deepTutorPane && deeptutorSplitter) {
+				let isDeepTutorOpen = !deepTutorPane.hidden && deepTutorPane.getAttribute('collapsed') !== 'true';
+				if (isDeepTutorOpen) {
+					Zotero.debug('Tabs: Collapsing DeepTutor pane when switching to reader mode');
+					deepTutorPane.hidden = true;
+					deepTutorPane.setAttribute('collapsed', 'true');
+					deeptutorSplitter.setAttribute('state', 'collapsed');
+					// Update layout constraints after collapsing
+					if (typeof ZoteroPane !== 'undefined' && ZoteroPane.updateLayoutConstraints) {
+						ZoteroPane.updateLayoutConstraints();
+					}
+				}
+			}
+		}
+		*/
+		
 		if (tab.type === 'reader-unloaded') {
 			tab.type = "reader-loading";
 			// Make sure the loading message is displayed first.

--- a/scss/components/_splitter.scss
+++ b/scss/components/_splitter.scss
@@ -70,7 +70,8 @@ splitter {
 
 #zotero-items-splitter,
 #zotero-context-splitter,
-#zotero-context-splitter-stacked {
+#zotero-context-splitter-stacked,
+#zotero-deeptutor-splitter {
 	&[orient=vertical] {
 		&[state="collapsed"] {
 			margin-bottom: -1px;


### PR DESCRIPTION
Redesign session History Search Bar hide/show
Change session deletion popup to global according to global popup style
Check session call returned document data (might still be API call issue)
Give fall back action of copy to clipboard to sign up
Fix responsiveness case for welcome pane and no-session pane (Seems ok)
Fix lefthand side border
Close deeptutor pane when switch to reader mode (implemented but commented)
Close sign in pane after opening google sign in (Checked not not implemented, as other platforms might be fine)
Decrease size of trash image in document list
Change highlight button color
Make registration pane have the same style
